### PR TITLE
Fix missing kernel/stdlib

### DIFF
--- a/src/pp_record.app.src
+++ b/src/pp_record.app.src
@@ -4,7 +4,7 @@
   {vsn, "0.1.3"},
   {modules, []},
   {registered, []},
-  {applications, []},
+  {applications, [kernel, stdlib]},
   {maintainers, ["Sam Tavakoli"]},
   {licenses, ["Erlang Public License"]},
   {links, [{"Github", "https://github.com/sata/pp_record"}]}


### PR DESCRIPTION
This little fix the following warnings:

```bash
===> "_build/default/lib/pp_record/ebin/pp_record.app" is missing kernel from applications list
===> "_build/default/lib/pp_record/ebin/pp_record.app" is missing stdlib from applications list
```